### PR TITLE
Fix DB con. in env example + Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,12 @@ https://eland.readthedocs.io/en/latest/
 ## Run as-is using Docker:
 - Navigate to the root folder of the downloaded repo.
 - using the file env.example as a template, construct your .env file with all of the necessary credentials required to run the demo.
+- Option 1 : Use the prebuild docker container:
+````
+sudo docker run --env-file .env -d --name elastic-bank -p 8000:8000 ghcr.io/TimBrophy/elastic-enabled-bank
+````
 
-- Build the container image:
+- Option 2 : Build the container image:
 ````
 sudo docker build -t <your_chosen_image_name> .
 ````

--- a/env.example
+++ b/env.example
@@ -28,4 +28,4 @@ ELASTIC_APM_SECRET_TOKEN= # set to APM secret token
 ELASTIC_APM_SERVER_URL= # set to APM Integration Server URL
 ELASTIC_APM_ENVIRONMENT=testing # APM environment name
 ELASTIC_APM_API_KEY= # APM API Key, generated from APM integration
-DATABASE_URL=sqlite:///data/db.sqlite3 # use the local db, or use postgres://..., mysql:// etc urls
+DATABASE_URL=sqlite:////app/db.sqlite3 # use the local db, or use postgres://..., mysql:// etc urls


### PR DESCRIPTION
Fixing connection env example by : 
1. Adding an additional "/" as django was looking into another folder.
2. moving /data/db.sqlite3 to /app/db.sqlite3 as per this [line](https://github.com/TimBrophy/elastic-enabled-bank/blob/0f41ce8b605889928989692a3b5c304303ef899a/Dockerfile#L28) we copy all the data into /app